### PR TITLE
Updates project to work with Webpack 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Use [npm version](https://docs.npmjs.com/cli/version) to bump your package versi
 yarn add --dev webpack-manifest-version-sync-plugin
 ```
 
+or
+
+```sh
+npm install webpack-manifest-version-sync-plugin --save-dev
+```
+
 ## Usage
 
 ```js


### PR DESCRIPTION
With Webpack 5, ``compilations.assets`` is sealed after compilation. So, for this to work, the hook used had to be an earlier one.

This PR fix it and adds instruction to install using npm.